### PR TITLE
make: Allow setting OS from the command line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.o
+hid_listen
+hid_listen.exe

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 PROG = hid_listen
 
-OS = LINUX
-#OS = DARWIN
-#OS = WINDOWS
+# Target OS (default Linux):
+# LINUX / DARWIN / WINDOWS
+OS ?= LINUX
 
 
 ifeq ($(OS), LINUX)


### PR DESCRIPTION
Build for specific OS by passing OS to make. Example:
```
make OS=DARWIN hid_listen
```

Defaults to `OS=LINUX`