### PR TITLE
Add support for FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,21 @@
 PROG = hid_listen
 
 # Target OS (default Linux):
-# LINUX / DARWIN / WINDOWS
+# LINUX / FREEBSD / DARWIN / WINDOWS
 OS ?= LINUX
 
+# Defaults
+TARGET ?= $(PROG)
+CC ?= cc
+CFLAGS ?= -O2 -Wall -D$(OS)
+STRIP ?= strip
+LIBS ?=
 
+# Potential per-OS overrides
 ifeq ($(OS), LINUX)
-TARGET = $(PROG)
-CC = gcc
-STRIP = strip
-CFLAGS = -O2 -Wall -D$(OS)
-LIBS =
+else ifeq ($(OS), FREEBSD)
 else ifeq ($(OS), DARWIN)
-TARGET = $(PROG)
 CC = gcc
-STRIP = strip
 CFLAGS = -O2 -Wall -D$(OS) -arch x86_64
 LIBS = -framework IOKit -framework CoreFoundation
 else ifeq ($(OS), WINDOWS)
@@ -22,7 +23,6 @@ TARGET = $(PROG).exe
 CC = i586-mingw32msvc-gcc
 STRIP = i586-mingw32msvc-strip
 WINDRES = i586-mingw32msvc-windres
-CFLAGS =  -O2 -Wall -D$(OS)
 LIBS = -lhid -lsetupapi
 KEY_SPC = ~/bin/cert/mykey.spc
 KEY_PVK = ~/bin/cert/mykey.pvk
@@ -36,7 +36,7 @@ OBJS = hid_listen.o rawhid.o
 all: $(TARGET)
 
 $(PROG): $(OBJS)
-	gcc -o $(PROG) $(OBJS) $(LIBS)
+	$(CC) -o $(PROG) $(OBJS) $(LIBS)
 	$(STRIP) $(PROG)
 
 $(PROG).app: $(PROG) Info.plist
@@ -58,8 +58,6 @@ $(PROG).exe: $(OBJS)
 
 resource.o: resource.rs icons/$(PROG).ico
 	$(WINDRES) -o resource.o resource.rs
-
-
 
 clean:
 	rm -f *.o $(PROG) $(PROG).exe $(PROG).exe.bak $(PROG).dmg

--- a/rawhid.c
+++ b/rawhid.c
@@ -46,11 +46,11 @@
 
 /*************************************************************************/
 /**                                                                     **/
-/**                             Linux                                   **/
+/**                             Linux / FreeBSD                         **/
 /**                                                                     **/
 /*************************************************************************/
 
-#if defined(LINUX) || defined(__LINUX__)
+#if defined(LINUX) || defined(__LINUX__) || defined(FREEBSD) || defined(__FreeBSD__)
 #define OPERATING_SYSTEM linux
 #include <fcntl.h>
 #include <errno.h>
@@ -58,7 +58,16 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
+#ifdef __FreeBSD__
+// You need to load hidraw(4) first, put the following in /boot/loader.conf:
+// hw.usb.usbhid.enable=1
+// usbhid_load="YES"
+// hidraw_load="YES"
+#include <dev/hid/hidraw.h>
+#define HIDRAW_MAX_DEVICES 0xff  // arbitrary value
+#else
 #include <linux/hidraw.h>
+#endif
 
 
 struct rawhid_struct {
@@ -234,7 +243,7 @@ void rawhid_list_close(rawhid_list_t *list)
 #endif
 
 
-#endif // linux
+#endif // linux / FreeBSD
 
 
 /*************************************************************************/


### PR DESCRIPTION
It's the same logic as with hidraw under Linux, so sprinkle some ifdef
magic around.

While here, have a defaults and overrides section in the Makefile; fix a
missing $(CC) variable and also default it to 'cc', which usually does
the right thing with gcc/clang depending on the user's preference.